### PR TITLE
Remove use of 'ToList'

### DIFF
--- a/RogueboyLevelEditor/Forms/MapEditorForm.cs
+++ b/RogueboyLevelEditor/Forms/MapEditorForm.cs
@@ -65,11 +65,13 @@ namespace RogueboyLevelEditor.Forms
 
             mapsMenu.DropDown.ItemClicked += (obj, args) =>
             {
-                if (args.ClickedItem.Tag is string)
-                    mapsMenu.DropDown.AutoClose = ((string)args.ClickedItem.Tag != keepOpen);
+                if (args.ClickedItem.Tag is string tag)
+                    mapsMenu.DropDown.AutoClose = (tag != keepOpen);
+                else
+                    mapsMenu.DropDown.AutoClose = true;
             };
 
-            foreach(var toolStrip in mapsMenu.DropDownItems.OfType<ToolStripMenuItem>().Where(x => (x.Tag is string) && (string)x.Tag == keepOpen))
+            foreach(var toolStrip in mapsMenu.DropDownItems.OfType<ToolStripMenuItem>().Where(x => (x.Tag is string tag) && (tag == keepOpen)))
                 toolStrip.CheckedChanged +=
                     (obj, args) => mapsMenu.DropDown.AutoClose = true;
 


### PR DESCRIPTION
Using a plain `foreach` to skip the unnecessary construction of the `List<T>`.

Constructing the `List<T>` is expensive for three reasons:
* It requires memory allocation, both for the `List<T>` itself and its underlying array
* It requires an `O(n)` copy of the elements of the source enumerable
* When the source enumerable _isn't_ an `ICollection<T>`, every element is added with `Add`,
  which can mean additional allocations and copying