### PR TITLE
Fix potential memory leak due cyclic dependency

### DIFF
--- a/RogueboyLevelEditor/Forms/MapEditorForm.cs
+++ b/RogueboyLevelEditor/Forms/MapEditorForm.cs
@@ -478,8 +478,13 @@ namespace RogueboyLevelEditor.Forms
                 return;
             }
 
-            mapsMenu.DropDownItems.RemoveByKey(mapCollection.CurrentMap.Name);
-            mapCollection.RemoveMap(mapCollection.CurrentMap);
+            using (var oldMenuItem = mapsMenu.DropDownItems[mapCollection.CurrentMap.Name])
+            {
+                oldMenuItem.Click -= changeMap_Click;
+
+                mapsMenu.DropDownItems.RemoveByKey(mapCollection.CurrentMap.Name);
+                mapCollection.RemoveMap(mapCollection.CurrentMap);
+            }
 
             if (mapCollection.OpenCount > 0)
             {
@@ -490,11 +495,9 @@ namespace RogueboyLevelEditor.Forms
                 UpdateCurrentSprites();
                 UpdateCurrentConnectors();
                 return;
-
             }
 
             this.Close();
-
         }
 
         private void mapMoveUpMenu_Click(object sender, EventArgs e)


### PR DESCRIPTION
When an event isn't deregistered,
there's a cyclic dependency between the event subscriber and the event provider.
Such cyclic dependencies cause memory leaks when one object outlives the other.
In this case the cycle is between the form class and the menu items,
meaning the menu items aren't deallocated because the form lives on.
This fix breaks the cycle and thus allows the memory to be reclaimed.