### PR TITLE
Create .editorconfig

### DIFF
--- a/ForgeLevelEditor/.editorconfig
+++ b/ForgeLevelEditor/.editorconfig
@@ -1,0 +1,16 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+# See also: https://docs.microsoft.com/en-us/visualstudio/ide/create-portable-custom-editor-options?view=vs-2017
+
+###############################
+# Core EditorConfig Options   #
+###############################
+
+root = true
+
+# Code files
+[*.{cs,csx,vb,vbx}]
+charset = utf-8-bom
+indent_size = 4
+indent_style = space
+end_of_line = lf
+insert_final_newline = true


### PR DESCRIPTION
Following up from [this comment](https://github.com/Dreamer2345/Forge-Level-Editor/issues/41#issuecomment-637742317), creating this `.editorconfig` file _should_ prevent any more line ending mishaps.

I'm reluctant to suggest it'll fix issue #41 because I haven't actually got round to testing it properly, but hopefully it will.
(I'd need to test editing a copy of the repo without the `.editorconfig` and compare it to a copy that has the `.editorconfig` file.)